### PR TITLE
Fix tests to reflect changes in REPOSLUG parameter handling.

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -6,7 +6,7 @@ def test_no_reposlug():
              f'--config-auth "{config("auth.fff.cfg")}"')
     assert cp.returncode != 0
     assert not cp.stdout
-    assert 'Error: Missing argument "REPOSLUG".' in cp.stderr
+    assert 'Error: Missing argument "REPOSLUG...".' in cp.stderr
 
 
 def test_no_config():
@@ -59,4 +59,4 @@ def test_invalid_reposlug():
              'foobar')
     assert cp.returncode != 0
     assert not cp.stdout
-    assert 'Error: Invalid value for "REPOSLUG": not in owner/repository format' in cp.stderr
+    assert 'Error: Invalid value for "REPOSLUG...": not in owner/repository format' in cp.stderr


### PR DESCRIPTION
The asyncio version of the assignment requires the app to be capable of
handling multiple REPOSLUG parameters. The most straightforward way to
do so seems to be nargs=-1 parameter for the click.argument decorator,
which adds three dots after the parameter name in help message and all
error messages. This commit introduces the same change to the tests.